### PR TITLE
Extract claim private key from pdf

### DIFF
--- a/packages/verification-vue-component/src/components/CertifactionVerification.vue
+++ b/packages/verification-vue-component/src/components/CertifactionVerification.vue
@@ -200,7 +200,7 @@ export default {
                 hashingService.hashFile(pdfBytes),
                 this.pdfService.extractEncryptionKeys(pdfBytes)
             ])
-            const decryptionKey = (encryptionKeys !== null) ? encryptionKeys.privateKey : null
+            const decryptionKey = (encryptionKeys !== null) ? encryptionKeys.claimPrivateKey : null
 
             let verification = await this.certifactionEthVerifier.verify(fileHash, decryptionKey)
 


### PR DESCRIPTION
Assumption is that bug was introduced by renaming privateKey -> claimPrivateKey in pdf repo with commit: 188504269bf206bfda9a3d0675fc348786187829