### PR TITLE
Remove blockchain mentions for signing results

### DIFF
--- a/packages/verification-vue-component/src/locales/de.json
+++ b/packages/verification-vue-component/src/locales/de.json
@@ -89,12 +89,12 @@
             "signature": {
                 "level": {
                     "standard": {
-                        "title": "Blockchain eSignature",
-                        "description": "Die digitalen Unterschriften dieses Dokuments sind kryptografisch durch zeitgestempelte, unveränderliche Einträge in der Ethereum-Blockchain gesichert. Bitte sehen Sie sich die Details der Signaturen, um zu erfahren, wie die Identität der einzelnen Unterzeichner überprüft wurde. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Mehr erfahren</a>"
+                        "title": "Standard-eSignatur",
+                        "description": "Die digitalen Unterschriften dieses Dokuments sind kryptografisch durch zeitgestempelte, unveränderliche Einträge gesichert. Bitte sehen Sie sich die Details der Signaturen, um zu erfahren, wie die Identität der einzelnen Unterzeichner überprüft wurde. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Mehr erfahren</a>"
                     },
                     "QES": {
-                        "title": "Blockchain eSignature + Qualified Electronic Signature (QES)",
-                        "description": "Die Unterschriften, die für dieses Dokument geleistet wurden, sind konform mit dem Schweizer Bundesgesetz über die elektronische Signatur und weisen die höchste darin vorgesehene Beweiskraft auf. Darüber hinaus wurde das Dokument durch einen zeitgestempelten, unveränderlichen Eintrag in der Ethereum-Blockchain gesichert. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Mehr erfahren</a>"
+                        "title": "Qualifizierte elektronische Signatur (QES)",
+                        "description": "Die Unterschriften, die für dieses Dokument geleistet wurden, sind konform mit dem Schweizer Bundesgesetz über die elektronische Signatur und weisen die höchste darin vorgesehene Beweiskraft auf. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Mehr erfahren</a>"
                     }
                 }
             },

--- a/packages/verification-vue-component/src/locales/en.json
+++ b/packages/verification-vue-component/src/locales/en.json
@@ -89,12 +89,12 @@
             "signature": {
                 "level": {
                     "standard": {
-                        "title": "Blockchain eSignature",
-                        "description": "The signatures given to this document are cryptographically secured by timestamped, immutable records on the Ethereum blockchain. Please see the signature details above to learn how the identity of each signer was verified. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Learn more</a>"
+                        "title": "Standard eSignature",
+                        "description": "The signatures given to this document are cryptographically secured by timestamped, immutable records. Please see the signature details above to learn how the identity of each signer was verified. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Learn more</a>"
                     },
                     "QES": {
-                        "title": "Blockchain eSignature +<br>Qualified Electronic Signature (QES)",
-                        "description": "The signatures given to this document comply with the Swiss Federal Electronic Signature Act and hold the maximum legal weight achievable for electronic signatures in Switzerland. In addition, the document was secured by a time-stamped, immutable record on the Ethereum blockchain. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Learn more</a>"
+                        "title": "Qualified Electronic Signature (QES)",
+                        "description": "The signatures given to this document comply with the Swiss Federal Electronic Signature Act and hold the maximum legal weight achievable for electronic signatures in Switzerland. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Learn more</a>"
                     }
                 }
             },

--- a/packages/verification-vue-component/src/locales/fr.json
+++ b/packages/verification-vue-component/src/locales/fr.json
@@ -93,7 +93,7 @@
                         "description": "Les signatures électroniques de ce document sont sécurisées cryptographiquement par des entrées immuables horodatées. Veuillez consulter les détails des signatures pour savoir comment l'identité de chaque signataire a été vérifiée. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">En savoir plus</a>"
                     },
                     "QES": {
-                        "title": "eSignature sur la Blockchain +<br>Signature Électronique Qualifiée (QES)",
+                        "title": "Signature Électronique Qualifiée (QES)",
                         "description": "Les signatures de ce document sont conformes à la loi fédérale suisse sur la signature électronique et ont la plus haute valeur probante prevue par cette loi. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">En savoir plus</a>"
                     }
                 }

--- a/packages/verification-vue-component/src/locales/fr.json
+++ b/packages/verification-vue-component/src/locales/fr.json
@@ -89,12 +89,12 @@
             "signature": {
                 "level": {
                     "standard": {
-                        "title": "eSignature sur la Blockchain",
-                        "description": "Les signatures électroniques de ce document sont sécurisées cryptographiquement par des entrées immuables horodatées dans la blockchain Ethereum. Veuillez consulter les détails des signatures pour savoir comment l'identité de chaque signataire a été vérifiée. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">En savoir plus</a>"
+                        "title": "Signature électronique standard",
+                        "description": "Les signatures électroniques de ce document sont sécurisées cryptographiquement par des entrées immuables horodatées. Veuillez consulter les détails des signatures pour savoir comment l'identité de chaque signataire a été vérifiée. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">En savoir plus</a>"
                     },
                     "QES": {
                         "title": "eSignature sur la Blockchain +<br>Signature Électronique Qualifiée (QES)",
-                        "description": "Les signatures de ce document sont conformes à la loi fédérale suisse sur la signature électronique et ont la plus haute valeur probante prevue par cette loi. En outre, ce document a été sécurisé par une entrée immuable et horodatée dans la blockchain Ethereum. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">En savoir plus</a>"
+                        "description": "Les signatures de ce document sont conformes à la loi fédérale suisse sur la signature électronique et ont la plus haute valeur probante prevue par cette loi. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">En savoir plus</a>"
                     }
                 }
             },

--- a/packages/verification-vue-component/src/locales/it.json
+++ b/packages/verification-vue-component/src/locales/it.json
@@ -89,12 +89,12 @@
             "signature": {
                 "level": {
                     "standard": {
-                        "title": "Blockchain eSignature",
-                        "description": "Le firme applicate al documento sono crittograficamente assicurate da record immutabili e timestamped sulla blockchain Ethereum. Guarda i dettagli delle firme qui sopra per scoprire com'è stata verificata l'identità di ogni firmatario. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Scopri di più</a>"
+                        "title": "Firma elettronica standard",
+                        "description": "Le firme applicate al documento sono crittograficamente assicurate da record immutabili e timestamped. Guarda i dettagli delle firme qui sopra per scoprire com'è stata verificata l'identità di ogni firmatario. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Scopri di più</a>"
                     },
                     "QES": {
-                        "title": "Blockchain eSignature +<br>Firma Elettronica Qualificata (QES)",
-                        "description": "Le firme su questo documento sono conformi alla legge federale sui servizi di certificazione nel campo della firma elettronica e di altre applicazioni di certificati digitali ed hanno il valore legale più alto per una firma in Svizzera. Inoltre, il documento è stato assicurato da un timestamp immutabile sulla blockchain Ethereum. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Scopri di più</a>"
+                        "title": "Firma elettronica qualificata (QES)",
+                        "description": "Le firme su questo documento sono conformi alla legge federale sui servizi di certificazione nel campo della firma elettronica e di altre applicazioni di certificati digitali ed hanno il valore legale più alto per una firma in Svizzera. <a href=\"https://certifaction.io/blockchain-esignatures/\" target=\"_blank\">Scopri di più</a>"
                     }
                 }
             },


### PR DESCRIPTION
This is a quick fix to remove the most prominent mention of the word "blockchain" in the verification tool.
The "signature type" is currently displayed at the bottom of the result and is immediately visible.

The intention is to leave the rest of the blockchain mentions (e.g. in the technical details) for now.