### PR TITLE
chore: switch from Infura to Alchemy

### DIFF
--- a/packages/verification-core/README.md
+++ b/packages/verification-core/README.md
@@ -31,7 +31,7 @@ import { CertifactionEthVerifier } from '@certifaction/verification-core'
 const certifactionEthVerifier = new CertifactionEthVerifier()
 // or with custom properties (the values shown here are the default values)
 const certifactionEthVerifier = new CertifactionEthVerifier(
-    'https://mainnet.infura.io/v3/4559d381898847c0b13ced86a45a4ec0', // providerUrl
+    'https://eth-mainnet.g.alchemy.com/v2/alch_JbdRvqDwaZtIctAtRwxaz', // providerUrl
     '0xdc1d2c136cad73e10ae367d075995185edd68cae', // legacyContractAddress
     ['0xf73e27c5008ff487803d2337fc3ac4016f6526e4', '0x5ee4ec3cbee909050e68c7ff7a8b422cfbd72244'], // legacyContractFallbackAddresses
     '0x5532ba4add77dd25fa11acc5a84e5f183f57525e', // claimContractAddress

--- a/packages/verification-core/src/verifier/CertifactionEthVerifier.ts
+++ b/packages/verification-core/src/verifier/CertifactionEthVerifier.ts
@@ -22,7 +22,7 @@ export default class CertifactionEthVerifier {
      * @param certifactionApiUrl
      */
     constructor(
-        providerUrl: string = 'https://mainnet.infura.io/v3/4559d381898847c0b13ced86a45a4ec0',
+        providerUrl: string = 'https://eth-mainnet.g.alchemy.com/v2/alch_JbdRvqDwaZtIctAtRwxaz',
         legacyContractAddress: string = '0xdc1d2c136cad73e10ae367d075995185edd68cae',
         legacyContractFallbackAddresses: string[] = [
             '0xf73e27c5008ff487803d2337fc3ac4016f6526e4',

--- a/packages/verification-vue-component/README.md
+++ b/packages/verification-vue-component/README.md
@@ -164,7 +164,7 @@ chainWebpack: config => {
 
 #### providerUrl
 
-Type: `string` | Required: `false` | Default: `https://mainnet.infura.io/v3/4559d381898847c0b13ced86a45a4ec0`
+Type: `string` | Required: `false` | Default: `https://eth-mainnet.g.alchemy.com/v2/alch_JbdRvqDwaZtIctAtRwxaz`
 
 #### legacyContractAddress
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented default Ethereum provider endpoint to Alchemy Mainnet.

* **Bug Fixes**
  * Updated the verifier’s default Ethereum provider configuration to use Alchemy Mainnet instead of Infura.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->